### PR TITLE
Create ext.properties

### DIFF
--- a/event/ext.properties
+++ b/event/ext.properties
@@ -1,0 +1,11 @@
+[event]
+group = Runtime
+help = Settings for Event extension
+
+use_xpcall.type = bool
+use_xpcall.default = 0
+use_xpcall.label = Use xpcall
+
+use_pcall.type = bool
+use_pcall.default = 1
+use_pcall.label = Use pcall


### PR DESCRIPTION
[Soon](https://github.com/defold/defold/pull/11125), it will be possible to show extension settings in the `game.project` form. This PR adds `ext.properties` to show used settings:
<img width="634" height="788" alt="Screenshot 2025-08-22 at 15 53 00" src="https://github.com/user-attachments/assets/804988cf-0436-4ead-83fe-2941feda6051" />
